### PR TITLE
fix for rv_histogram

### DIFF
--- a/docs/markdown/point_source_likelihood.md
+++ b/docs/markdown/point_source_likelihood.md
@@ -79,8 +79,8 @@ Now let's think about the energy-dependent term. The way this is handled is to m
 Doing this properly requires a knowledge of the relationship between the true and reconstructed energies as well as the details of the power law model. The most straightforward way to implement this is to simulate the a large number of events using the `Simulator` and build a likelihood using the output of this simulation and `MarginalisedEnergyLikelihoodFromSim`. We do exactly this with pre-computed lists of events, to be found in the data subdirectory: `sim_output_{index}.h5`. These were simulated using point sources with spectral index `index` at 45 degrees declination. The likelihood is restricted to a small band of declination around the assumed source. Using the same declination for our test source, this is fine. For different source declinations further simulations would be needed to account for the declination dependence of the detector acceptance.
 
 ```python
-aeff = EffectiveArea.from_dataset("20210126", period="IC86_I")
-irf = R2021IRF.from_period("IC86_I")
+aeff = EffectiveArea.from_dataset("20210126", period="IC86_II")
+irf = R2021IRF.from_period("IC86_II")
 new_reco_bins = irf.reco_energy_bins[12, 2]
 energy_likelihood = MarginalisedIntegratedEnergyLikelihood(irf, aeff, new_reco_bins)
 #energy_likelihood = MarginalisedEnergyLikelihood2021([1.5, 2.0, 2.5, 3.0, 3.5, 3.7, 4.0], 'data', 'sim_output', np.pi/4,)
@@ -112,7 +112,7 @@ Now we can bring together the spatial and energy terms to build a full `PointSou
 
 ```python
 data = {}
-with h5py.File("data/p_IC86_I_test_sim.h5", "r") as f:
+with h5py.File("data/p_IC86_II_test_sim.h5", "r") as f:
     for key in f:
         if "source_0" not in key and "source_1" not in key:
             data[key] = f[key][()]
@@ -211,6 +211,10 @@ ax.set_xlabel("Number of point source events in dataset")
 ax.set_ylabel("Test statistic value")
 ```
 
+```python
+test_statistics
+```
+
 So the more neutrinos are seen from a source, the easier that source is to detect.
 
 Let's have a look at the minuit object returned by `_minimize()`. In case something is off with the fit, we can use it as a starting point for debugging.
@@ -261,7 +265,7 @@ For the simulation-based energy likelihood used in the following, the profile o 
 The error provided by `migrad()` is unreasonably small.
 
 ```python
-energy_likelihood = MarginalisedEnergyLikelihood2021(np.round(np.arange(1.5, 4.1, 0.2), decimals=1), 'data', 'p_IC86_I', np.deg2rad(30))
+energy_likelihood = MarginalisedEnergyLikelihood2021(np.round(np.arange(1.5, 4.1, 0.2), decimals=1), 'data', 'p_IC86_II', np.deg2rad(30))
 energy_likelihood._min_index = 1.55
 energy_likelihood._max_index = 3.85
 likelihood = PointSourceLikelihood(spatial_likelihood, energy_likelihood, 
@@ -302,9 +306,9 @@ plt.title(f"index = {m.values['index']:.1f} - {m.values['index']-lower_lim:.1f} 
 ```python
 source_coords = (np.pi, np.deg2rad(30))
 #index_list = list(np.arange(1.5, 4.25, 0.25))
-event_files = ["data/p_IC86_I_test_sim.h5", "data/p_IC86_II_test_sim.h5"]
+event_files = ["data/p_IC86_II_test_sim.h5"]
 tllh = TimeDependentPointSourceLikelihood(
-    source_coords, ["IC86_I", "IC86_II"], event_files, MarginalisedIntegratedEnergyLikelihood, path="data")
+    source_coords, ["IC86_II"], event_files, MarginalisedIntegratedEnergyLikelihood, path="data")
 
 m = tllh._minimize()
 

--- a/icecube_tools/detector/r2021.py
+++ b/icecube_tools/detector/r2021.py
@@ -76,7 +76,7 @@ class R2021IRF(EnergyResolution, AngularResolution):
                 n, bins = self._marginalisation(c_e, c_d)
                 #if n.max() > self.ereco_pdf_max:
                 #    self.ereco_pdf_max = n.max()
-                self.reco_energy[c_e, c_d] = rv_histogram((n, bins))
+                self.reco_energy[c_e, c_d] = rv_histogram((n, bins), density=False)
                 self.reco_energy_bins[c_e, c_d] = bins
         self._values = []
         logger.debug('Creating empty dicts for kinematic angle dists and angerr dists')
@@ -240,7 +240,7 @@ class R2021IRF(EnergyResolution, AngularResolution):
                         logger.debug(f'Creating kinematic angle dist for {idx_e}, {idx_d}, {idx_e_r}')
                         n, bins = self._marginalize_over_angerr(idx_e, idx_d, idx_e_r)
                         self.marginal_pdf_psf.add(bins, idx_e, idx_d, idx_e_r, 'bins')
-                        self.marginal_pdf_psf.add(rv_histogram((n, bins)), idx_e, idx_d, idx_e_r, 'pdf')
+                        self.marginal_pdf_psf.add(rv_histogram((n, bins), density=False), idx_e, idx_d, idx_e_r, 'pdf')
                         kinematic_angle[_index_r] = self.marginal_pdf_psf(idx_e, idx_d, idx_e_r, 'pdf').rvs(size=_index_r[0].size, random_state=seed)
 
                     current_c_k = self._return_kinematic_bins(idx_e, idx_d, idx_e_r, kinematic_angle[_index_r])
@@ -256,7 +256,7 @@ class R2021IRF(EnergyResolution, AngularResolution):
                         except KeyError as KE:
                             logger.debug(f'Creating AngErr dist for {idx_e}, {idx_d}, {idx_e_r}, {idx_k}')
                             n, bins = self._get_angerr_dist(idx_e, idx_d, idx_e_r, idx_k)
-                            self.marginal_pdf_angerr.add(rv_histogram((n, bins)), idx_e, idx_d, idx_e_r, idx_k, 'pdf') 
+                            self.marginal_pdf_angerr.add(rv_histogram((n, bins), density=False), idx_e, idx_d, idx_e_r, idx_k, 'pdf') 
                             self.marginal_pdf_angerr.add(bins, idx_e, idx_d, idx_e_r, idx_k, 'bins')
                             ang_err[_index_k] = self.marginal_pdf_angerr(idx_e, idx_d, idx_e_r, idx_k, 'pdf').rvs(size=_index_k[0].size, random_state=seed)
 

--- a/icecube_tools/point_source_likelihood/energy_likelihood.py
+++ b/icecube_tools/point_source_likelihood/energy_likelihood.py
@@ -596,7 +596,7 @@ class MarginalisedEnergyLikelihoodBraun2008(MarginalisedEnergyLikelihood):
 
         self._max_index = max(index_list)
 
-    def __call__(self, energy, index):
+    def __call__(self, energy, index, dec=0):
         """
         Return P(Ereco | index)
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ project_urls =
 packages = find:
 install_requires =
     numpy
-    scipy < 1.9.1
+    scipy
     matplotlib
     astropy
     iminuit

--- a/tests/test_angular_resolution.py
+++ b/tests/test_angular_resolution.py
@@ -38,7 +38,7 @@ def test_angular_resolution():
 def test_r2021_irf():
 
     # Load
-    irf = R2021IRF.from_period("IC86_I")
+    irf = R2021IRF.from_period("IC86_II")
 
     # Sample
     ra = 0.0 # rad

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -60,5 +60,5 @@ def test_simulation():
 
 
 def test_new_simulation():
-    tsim = TimeDependentSimulator(["IC86_I", "IC86_II"], sources)
+    tsim = TimeDependentSimulator(["IC86_II"], sources)
     tsim.run(seed=42)

--- a/tests/test_time_detector.py
+++ b/tests/test_time_detector.py
@@ -9,7 +9,7 @@ period = "IC86_II"
 
 def test_time_dependent_icecube():
 
-    tic = TimeDependentIceCube.from_periods("IC86_I", "IC40")
+    tic = TimeDependentIceCube.from_periods("IC86_II")
     
     with raises(ValueError):
         tic = TimeDependentIceCube.from_periods("this_is_not_a_period")


### PR DESCRIPTION
Added kwarg `density=False` for scipy histograms.
Changed examples to IC86_II because of bug with other datasets relating to table entries consisting of too many zeros