### PR TITLE
Changed simulation procedure to be more memory friendly, Aeff and IRF accept same etrue/dec

### DIFF
--- a/icecube_tools/detector/r2021.py
+++ b/icecube_tools/detector/r2021.py
@@ -49,8 +49,8 @@ class DummyPDF():
             return 0.
 
 
-    #def rvs(self, size=1, random_state=42):
-    #    return
+    def rvs(self, size=1, random_state=42):
+        raise NotImplementedError("Dummies cannot be sampled from!")
 
 
 class R2021IRF(EnergyResolution, AngularResolution):

--- a/icecube_tools/point_source_likelihood/point_source_likelihood.py
+++ b/icecube_tools/point_source_likelihood/point_source_likelihood.py
@@ -284,8 +284,6 @@ class PointSourceLikelihood:
                 self._source_coord
             )
 
-            self._bg_llh_spatial = np.full(self._selected_energies.shape, 1. / self._band_solid_angle)
-
 
 
     def _signal_likelihood(
@@ -376,7 +374,7 @@ class PointSourceLikelihood:
                 return self._energy_likelihood(energy, index, dec)
         
         def spatial():
-            return self._bg_llh_spatial
+            return np.full(energy.shape, 1. / self._band_solid_angle)
 
         #Check which part is used for likelihood calculation
         if self.which == 'spatial':

--- a/icecube_tools/simulator.py
+++ b/icecube_tools/simulator.py
@@ -121,11 +121,11 @@ class Simulator(SimEvents):
 
         if not N:
 
-            self.N = np.random.poisson(sum(self._Nex))
+            self.N_events = np.random.poisson(sum(self._Nex))
 
         else:
 
-            self.N = int(N)
+            self.N_events = int(N)
 
         v_min = - self.max_cosz
         v_max = - self.min_cosz
@@ -138,7 +138,7 @@ class Simulator(SimEvents):
         self.coordinate = []
         self._ra = []
         self._dec = []
-        self._source_label = np.zeros(self.N, dtype=int)
+        self._source_label = np.zeros(self.N_events, dtype=int)
         self._ang_err = []        
 
         #During detector simulation, many events are discarded due to 
@@ -147,8 +147,8 @@ class Simulator(SimEvents):
         #the accepted ones.
 
         #TODO maybe change the factor to something spectral index dependent
-        num = self.N * 1000
-        label = np.random.choice(range(len(self.sources)), self.N, p=self._source_weights)
+        num = self.N_events * 1000
+        label = np.random.choice(range(len(self.sources)), self.N_events, p=self._source_weights)
         l_set = set(label)
         l_num = {i: np.argwhere(i == label).shape[0] for i in l_set}
         max_energy = {}
@@ -158,7 +158,7 @@ class Simulator(SimEvents):
         Etrue_d = {i: np.zeros(l_num[i]) for i in l_set}
         Earr_d = {i: np.zeros(l_num[i]) for i in l_set}
         
-        accepted = np.zeros(self.N, dtype=bool)
+        accepted = np.zeros(self.N_events, dtype=bool)
  
         #go over each source
         for i in l_set:
@@ -261,12 +261,12 @@ class Simulator(SimEvents):
 
         if not N:
 
-            self.N = np.random.poisson(sum(self._Nex))
+            self.N_events = np.random.poisson(sum(self._Nex))
             logger.info("Random N.")
 
         else:
 
-            self.N = int(N)
+            self.N_events = int(N)
             logger.info("N provided.")
 
         v_min = - self.max_cosz
@@ -286,8 +286,8 @@ class Simulator(SimEvents):
         #the accepted ones.
 
         #TODO maybe change the factor to something spectral index dependent
-        num = self.N * 10
-        label = np.random.choice(range(len(self.sources)), self.N, p=self._source_weights)
+        num = self.N_events * 10
+        label = np.random.choice(range(len(self.sources)), self.N_events, p=self._source_weights)
         l_set = set(label)
         l_num = {i: np.argwhere(i == label).shape[0] for i in l_set}
         max_energy = {}
@@ -297,9 +297,8 @@ class Simulator(SimEvents):
         Etrue_d = {i: np.zeros(l_num[i]) for i in l_set}
         Earr_d = {i: np.zeros(l_num[i]) for i in l_set}
         
-        accepted = np.zeros(self.N, dtype=bool)
         if show_progress:
-            progress = progress_bar(range(self.N), desc="Sampling", position=0, leave=True)
+            progress = progress_bar(range(self.N_events), desc="Sampling", position=0, leave=True)
         #go over each source
         for i in l_set:
             #simulate until appropriate number of events is accepted
@@ -307,7 +306,8 @@ class Simulator(SimEvents):
             max_energy[i] = self.sources[i].flux_model._upper_energy
             
             logger.info(f"Simulating source {i}")
-            while True:
+            not_done = True
+            while not_done:
                 #check if data is needed, else break loop
                 where_zero = np.argwhere(Etrue_d[i] == 0.)
                 if where_zero.size == 0:
@@ -356,7 +356,7 @@ class Simulator(SimEvents):
                 else:
                     start = np.min(where_zero)
                     end = start + idx[0].size
-                    # print("start:end", start, end)
+                    # 
                     try:
                         Etrue_d[i][start:end] = Etrue_[idx]
                         Earr_d[i][start:end] = Earr_[idx]
@@ -365,9 +365,12 @@ class Simulator(SimEvents):
                         logger.debug("All data placed.")
                         if show_progress:
                             progress.update(idx[0].size)
+                        num_samples = idx[0].size
+                        # print("start:end", start, end)
                     except (IndexError, ValueError):
                         logger.debug("Not enough slots, cutting short.")
                         remaining = np.argwhere(Etrue_d[i] == 0.).size
+                        end = start + remaining
                         # print("start:end", start, end)
                         # print("remaining:", remaining)
                         # print(Etrue_[idx][0:remaining])
@@ -378,91 +381,96 @@ class Simulator(SimEvents):
                         dec_d[i][start:] = dec_[idx][0:remaining]
                         if show_progress:
                             progress.update(remaining)
-                        break
-            # print("Sampling spectrum is done")
-            logger.info("Done sampling the spectrum") 
-            if not isinstance(self.detector.energy_resolution, R2021IRF):
-                logger.info("Sampled reco energy")
-                Ereco = self.detector.energy_resolution.sample(Earr_d[i])
-                #this and all following try-except TypeError blocks
-                #are needed if only a single event is sampled
-                #then list() will not work bc float is not an iterable
-                try:
-                    self._reco_energy += list(Ereco)           
-                except TypeError:
-                    self._reco_energy += [Ereco]
+                        not_done = False
+                    finally:
+                        if not isinstance(self.detector.energy_resolution, R2021IRF):
+                            logger.info("Sampled reco energy")
+                            Ereco = self.detector.energy_resolution.sample(Earr_d[i][start:end])
+                            #this and all following try-except TypeError blocks
+                            #are needed if only a single event is sampled
+                            #then list() will not work bc float is not an iterable
+                            try:
+                                self._reco_energy += list(Ereco)           
+                            except TypeError:
+                                self._reco_energy += [Ereco]
 
-            #do source type specific things here
-            if self.sources[i].source_type == DIFFUSE:
+                        #do source type specific things here
+                        if self.sources[i].source_type == DIFFUSE:
 
-                logger.info("Sampling angular uncertainty for diffuse source")
-                if isinstance(self.detector.angular_resolution, R2021IRF):
-                    _, _, reco_ang_err, Ereco = self.detector.angular_resolution.sample(
-                        (ra_d[i], dec_d[i]), np.log10(Earr_d[i]), seed=seed
-                    )
-                    try:
-                        self._ang_err += list(reco_ang_err)
-                        self._reco_energy += list(Ereco)
-                    except TypeError as e:
-                        print(e)
-                        self._ang_err += [reco_ang_err]
-                        self._reco_energy += [Ereco]
-                        
-                elif isinstance(self.detector.angular_resolution, AngularResolution):
-                    reco_ang_err = self.detector.angular_resolution.get_ret_ang_err(
-                        Earr_d[i]
-                    )
-                    try:
-                        self._ang_err += list(reco_ang_err)
-                    except TypeError:
-                        self._ang_err += [reco_ang_err]
-                elif isinstance(
-                    self.detector.angular_resolution, FixedAngularResolution
-                ):
-                    reco_ang_err = self.detector.angular_resolution.ret_ang_err
-                    #TODO fix
-                    temp = [reco_ang_err] * l_num[i]
+                            logger.info("Sampling angular uncertainty for diffuse source")
+                            if isinstance(self.detector.angular_resolution, R2021IRF):
+                                _, _, reco_ang_err, Ereco = self.detector.angular_resolution.sample(
+                                    (ra_d[i][start:end], dec_d[i][start:end]),
+                                    np.log10(Earr_d[i][start:end]),
+                                    seed=seed
+                                )
+                                try:
+                                    self._ang_err += list(reco_ang_err)
+                                    self._reco_energy += list(Ereco)
+                                except TypeError as e:
+                                    print(e)
+                                    self._ang_err += [reco_ang_err]
+                                    self._reco_energy += [Ereco]
+                                    
+                            elif isinstance(self.detector.angular_resolution, AngularResolution):
+                                reco_ang_err = self.detector.angular_resolution.get_ret_ang_err(
+                                    Earr_d[i][start:end]
+                                )
+                                try:
+                                    self._ang_err += list(reco_ang_err)
+                                except TypeError:
+                                    self._ang_err += [reco_ang_err]
+                            elif isinstance(
+                                self.detector.angular_resolution, FixedAngularResolution
+                            ):
+                                reco_ang_err = self.detector.angular_resolution.ret_ang_err
+                                #TODO fix
+                                logger.warning("Fixed angular resolution not tested, proceed at your own risk!")
+                                temp = [reco_ang_err] * l_num[i]
 
-                try:
-                    self._dec += list(dec_d[i])
-                    self._ra += list(ra_d[i])
-                except TypeError:
-                    self._dec += [dec_d[i]]
-                    self._ra += [ra_d[i]]
-                logger.info("Sampled angular uncertainty for diffuse source")
+                            try:
+                                self._dec += list(dec_d[i][start:end])
+                                self._ra += list(ra_d[i][start:end])
+                            except TypeError:
+                                self._dec += [dec_d[i]]
+                                self._ra += [ra_d[i]]
+                            logger.info("Sampled angular uncertainty for diffuse source")
 
-            else:
+                        else:
 
-                logger.info("Sampling angular uncertainty for point source")
-                if isinstance(self.detector.angular_resolution, R2021IRF):
-                    #loop over events handled inside R2021IRF
-                    reco_ra, reco_dec, reco_ang_err, Ereco  = self.detector.angular_resolution.sample(
-                        (ra_d[i], dec_d[i]), np.log10(Earr_d[i]), seed=seed)
-                    self._reco_energy += list(Ereco)
+                            logger.info("Sampling angular uncertainty for point source")
+                            if isinstance(self.detector.angular_resolution, R2021IRF):
+                                #loop over events handled inside R2021IRF
+                                reco_ra, reco_dec, reco_ang_err, Ereco = self.detector.angular_resolution.sample(
+                                    (ra_d[i][start:end], dec_d[i][start:end]),
+                                    np.log10(Earr_d[i][start:end]),
+                                    seed=seed)
+                                self._reco_energy += list(Ereco)
 
-                elif isinstance(self.detector.angular_resolution, AngularResolution):
-                    reco_ra, reco_dec = self.detector.angular_resolution.sample(
-                        Earr_d[i], (ra_d[i], dec_d[i])
-                    )
-                    reco_ang_err = self.detector.angular_resolution.ret_ang_err
+                            elif isinstance(self.detector.angular_resolution, AngularResolution):
+                                reco_ra, reco_dec = self.detector.angular_resolution.sample(
+                                    Earr_d[i][start:end],
+                                    (ra_d[i][start:end], dec_d[i][start:end])
+                                )
+                                reco_ang_err = self.detector.angular_resolution.ret_ang_err
 
-                elif isinstance(
-                    self.detector.angular_resolution, FixedAngularResolution
-                ):
-                    reco_ra, reco_dec = self.detector.angular_resolution.sample(
-                        (ra_d[i], dec_d[i])
-                    )
-                    reco_ang_err = self.detector.angular_resolution.ret_ang_err
-                try:
-                    self._ang_err +=list(reco_ang_err)
-                    self._dec += list(reco_dec)
-                    self._ra += list(reco_ra)
-                except TypeError as e:
-                    print(e)
-                    self._ang_err += [reco_ang_err]
-                    self._dec += [reco_dec]
-                    self._ra += [reco_ra]
-                logger.info("Sampled angular uncertainty for point source")
+                            elif isinstance(
+                                self.detector.angular_resolution, FixedAngularResolution
+                            ):
+                                reco_ra, reco_dec = self.detector.angular_resolution.sample(
+                                    (ra_d[i][start:end], dec_d[i][start:end])
+                                )
+                                reco_ang_err = self.detector.angular_resolution.ret_ang_err
+                            try:
+                                self._ang_err +=list(reco_ang_err)
+                                self._dec += list(reco_dec)
+                                self._ra += list(reco_ra)
+                            except TypeError as e:
+                                print(e)
+                                self._ang_err += [reco_ang_err]
+                                self._dec += [reco_dec]
+                                self._ra += [reco_ra]
+                            logger.info("Sampled angular uncertainty for point source")
 
         logger.info("Creating array of simulation data")  
         self._true_energy = np.concatenate(tuple(Etrue_d[k] for k in Earr_d.keys()))
@@ -577,7 +585,7 @@ class Braun2008Simulator:
         :param N: Number of events to simulate.
         """
 
-        self.N = N
+        self.N_events = N
 
         self._true_energy = []
         self._reco_energy = []
@@ -594,7 +602,7 @@ class Braun2008Simulator:
         max_energy = self.source.flux_model._upper_energy
 
         for i in progress_bar(
-            range(self.N), desc="Sampling", disable=(not show_progress)
+            range(self.N_events), desc="Sampling", disable=(not show_progress)
         ):
 
             accepted = False


### PR DESCRIPTION
For large event numbers in the simulations, the vMF sampling created humongously large arrays of floats leading to `MemoryError`. Simulation now proceeds block-wise, sampling the directional uncertainty and deflection in the same blocks in which events are sampled and accepted.

In the simulation notebook, this leads to the diffuse background having much smaller angular uncertainties. Might be a bug on either side of this PR, but compared to the previous data releases the "old" simulation had very much larger uncertainties.

Also changed the effective area (used for detection probability) to only have non-zero values where the IRF is defined. For IC59 this was not the case in the Southern hemisphere for low energies and for IC40 above 1e9 GeV.