### PR TITLE
Fixed bug in NeutrinoCalculator

### DIFF
--- a/icecube_tools/neutrino_calculator.py
+++ b/icecube_tools/neutrino_calculator.py
@@ -98,7 +98,7 @@ class NeutrinoCalculator:
         if self._energy_resolution is not None:
             for c_e in range(bin_c.size):
                 for c_c in range(czm.size):
-                    p_det_above_thr[c_e, c_c] = self._energy_resolution.p_det_above_threshold(np.exp(bin_c[c_e]), dec_c[c_c])
+                    p_det_above_thr[c_e, c_c] = self._energy_resolution.p_det_above_threshold(np.power(10, bin_c[c_e]), dec_c[c_c])
 
         aeff = self._selected_aeff * M_TO_CM ** 2   # 1st index is energy, 2nd is cosz
         dN_dt = integrated_spectrum.dot(aeff * p_det_above_thr).dot(integrated_direction)
@@ -132,7 +132,7 @@ class NeutrinoCalculator:
         p_det_above_thr = np.ones((bin_c.size))
         if self._energy_resolution is not None:
             for c in range(bin_c.size):
-                p_det_above_thr[c] = self._energy_resolution.p_det_above_threshold(np.exp(bin_c[c]), source.coord[1])
+                p_det_above_thr[c] = self._energy_resolution.p_det_above_threshold(np.power(10, bin_c[c]), source.coord[1])
 
         aeff = self._selected_aeff.T[selected_bin_index] * M_TO_CM ** 2
         # need to multiply with p(E detected above threshold)
@@ -140,7 +140,7 @@ class NeutrinoCalculator:
 
         dN_dt = np.dot(aeff * p_det_above_thr, integrated_flux)
 
-        return dN_dt * self._time * source.redshift_factor
+        return dN_dt * self._time
 
 
     def __call__(self, time=1, min_energy=1e2, max_energy=1e9, min_cosz=-1, max_cosz=1):

--- a/icecube_tools/source/flux_model.py
+++ b/icecube_tools/source/flux_model.py
@@ -116,6 +116,8 @@ class PowerLawFlux(FluxModel):
 
         lower_energy_bound = np.atleast_1d(lower_energy_bound)
         upper_energy_bound = np.atleast_1d(upper_energy_bound)
+        # check for bounds being sensible
+        assert np.all(upper_energy_bound - lower_energy_bound >= 0.)
 
         lower_energy_bound[lower_energy_bound < self._lower_energy] = self._lower_energy
         upper_energy_bound[upper_energy_bound > self._upper_energy] = self._upper_energy
@@ -124,10 +126,15 @@ class PowerLawFlux(FluxModel):
             np.power(self._normalisation_energy, -self._index) * (1 - self._index)
         )
 
-        return norm * (
+        output = norm * (
             np.power(upper_energy_bound, 1 - self._index)
             - np.power(lower_energy_bound, 1 - self._index)
         )
+
+        output[upper_energy_bound <= self._lower_energy] = 0.
+        output[lower_energy_bound >= self._upper_energy] = 0.
+
+        return output
 
     def total_flux_density(self):
         """

--- a/icecube_tools/source/flux_model.py
+++ b/icecube_tools/source/flux_model.py
@@ -114,8 +114,8 @@ class PowerLawFlux(FluxModel):
         """
         #works with np.ndarrays!
 
-        lower_energy_bound = np.atleast_1d(lower_energy_bound)
-        upper_energy_bound = np.atleast_1d(upper_energy_bound)
+        lower_energy_bound = np.atleast_1d(lower_energy_bound).copy()
+        upper_energy_bound = np.atleast_1d(upper_energy_bound).copy()
         # check for bounds being sensible
         assert np.all(upper_energy_bound - lower_energy_bound >= 0.)
 

--- a/icecube_tools/source/flux_model.py
+++ b/icecube_tools/source/flux_model.py
@@ -114,6 +114,12 @@ class PowerLawFlux(FluxModel):
         """
         #works with np.ndarrays!
 
+        lower_energy_bound = np.atleast_1d(lower_energy_bound)
+        upper_energy_bound = np.atleast_1d(upper_energy_bound)
+
+        lower_energy_bound[lower_energy_bound < self._lower_energy] = self._lower_energy
+        upper_energy_bound[upper_energy_bound > self._upper_energy] = self._upper_energy
+        
         norm = self._normalisation / (
             np.power(self._normalisation_energy, -self._index) * (1 - self._index)
         )


### PR DESCRIPTION
Accidentally used $e^x$ instead of $10^x$ for energies,
added a check for the powerlaw spectrum,
deleted redshift factor in NeutrinoCalculator since all quantities are defined in the detector frame.